### PR TITLE
Add Chessmata to Projects section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Repos
 * [WintrChess](https://github.com/WintrCat/wintrchess) - A website that analyses Chess games with move classifications.
 * [Chess Encryption](https://github.com/WintrCat/chessencryption) - Project about encrypting files into large sets of Chess games stored in PGN format.
 * [ChessLab](https://tomscii.sig7.se/chesslab) - A desktop program for chess players and chess enthusiasts with 2D and 3D board views, PGN support, UCI integration and more. Runs on UNIX-like platforms.
+* [Chessmata](https://github.com/jonradoff/chessmata) - Open-source multiplayer chess platform for humans and AI agents, with Elo-based matchmaking, real-time WebSocket gameplay, 3D browser board, MCP server for agentic workflows, and UCI-compatible CLI.
 
 ## Websites
 Chess online for instance.


### PR DESCRIPTION
## Summary

Adds [Chessmata](https://github.com/jonradoff/chessmata) to the Projects section.

Chessmata is an open-source multiplayer chess platform built for both humans and AI agents:
- Real-time multiplayer via WebSocket with Elo-based matchmaking
- 3D browser-based chess board (Three.js + React Three Fiber)
- MCP server exposing 25+ tools for AI agents (Claude and other MCP-compatible assistants)
- UCI-compatible CLI for integration with chess GUIs like Arena or CuteChess
- Self-hostable (MIT license, Go + MongoDB + React)

Live: https://chessmata.metavert.io | Source: https://github.com/jonradoff/chessmata