### PR TITLE
Fix broken Code of Conduct link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ If you want add or improve something - just make a fork & PR, fell free. Work on
 # Contribution Guidelines
 
 Please note that this project is released with a
-[Contributor Code of Conduct](code-of-conduct.md). By participating in this
+[Contributor Code of Conduct](CODE-OF-CONDUCT.md). By participating in this
 project you agree to abide by its terms.
 
 ---


### PR DESCRIPTION

- Fixed broken link in CONTRIBUTING.md from `code-of-conduct.md` to `CODE-OF-CONDUCT.md`
- The link was pointing to a file that doesn't exist (lowercase)  and leads to an error.  
- This fix correctly points to the actual CODE-OF-CONDUCT.md file.