### PR TITLE
Add Opening Trainer to Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Repos
 * [WintrChess](https://github.com/WintrCat/wintrchess) - A website that analyses Chess games with move classifications.
 * [Chess Encryption](https://github.com/WintrCat/chessencryption) - Project about encrypting files into large sets of Chess games stored in PGN format.
 * [ChessLab](https://tomscii.sig7.se/chesslab) - A desktop program for chess players and chess enthusiasts with 2D and 3D board views, PGN support, UCI integration and more. Runs on UNIX-like platforms.
+* [Opening Trainer](https://github.com/vancoeur/chess-opening-trainer) - A chess opening trainer for macOS: practice your own repertoires (PGN) with spaced repetition, bundled Stockfish analysis and Lichess explorer.
 
 ## Websites
 Chess online for instance.


### PR DESCRIPTION
Adds **Opening Trainer** — a free, open-source chess opening trainer for macOS (GPLv3, Python/PySide6): practice your own opening repertoires (PGN) with spaced repetition, bundled Stockfish analysis (repertoire check, move feedback, sparring, game review) and a Lichess opening explorer. English & German interface.

Repo: https://github.com/vancoeur/chess-opening-trainer