### PR TITLE
Add BetterBullet to Websites (develop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Chess online for instance.
 * [Noctie.ai](https://noctie.ai) – Practice chess against a humanlike chess bot and get feedback on your play.
 * [OpeningTrainer](https://openingtrainer.com) – Train openings by playing simulated games against the Lichess database.
 * [EndgameTrainer](https://endgametrainer.com) – 6000+ high-quality theoretical endgame positions.
+* [BetterBullet](https://betterbullet.xyz) - Bullet-specific (1+0) pacing analyzer comparing your clock use to rating-band benchmarks, for Lichess and Chess.com accounts.
 
 ## National chess federations
 


### PR DESCRIPTION
Same change as #51, opened against `develop` per CONTRIBUTING.md ("Work on develop branch") — following the precedent of the ChessLab pair (#41/#42). Happy to close either one if you only want a single PR.

BetterBullet is a bullet-chess (1+0) pacing analyzer: it charts where a player's time goes across a 60-second game, move by move, against rating-band pacing benchmarks built from the Lichess open database (CC0). Works with both Lichess and Chess.com accounts; analysis runs locally in the browser. There's a full free demo report with no account required.

Disclosure: I'm the developer.