### PR TITLE
Add Royal Shuffle Chess960 dataset to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Chess online for instance.
 * [Noctie.ai](https://noctie.ai) – Practice chess against a humanlike chess bot and get feedback on your play.
 * [OpeningTrainer](https://openingtrainer.com) – Train openings by playing simulated games against the Lichess database.
 * [EndgameTrainer](https://endgametrainer.com) – 6000+ high-quality theoretical endgame positions.
+* [Royal Shuffle Chess960 dataset](https://ch960.com/nomenclature) - Free CC0 dataset (JSON/CSV) classifying all 960 Chess960 starting positions into six board-fact families, with a nomenclature glossary.
 
 ## National chess federations
 


### PR DESCRIPTION
**Disclosure: I maintain this resource.**

Royal Shuffle Chess960 dataset — https://ch960.com/nomenclature

- Free, CC0-licensed dataset (JSON + CSV) classifying every one of the 960 Chess960 starting positions into one of six families, using only board-verifiable facts (king's starting file + whether a knight starts in a corner).
- Comes with a glossary of the nomenclature; the site also has all 960 positions on their own pages, browser puzzles and a daily position — free, no ads, no accounts.

Adding to the bottom of the Websites section per the guidelines (fork from `develop`). Happy to adjust the wording or withdraw if it doesn't fit the list's scope.