### PR TITLE
Add AhaMate (free one-move family chess game) to Websites

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Chess online for instance.
 * [chessgames](https://www.chessgames.com) - Online PGN chess game database and chess learning community.
 * [worldchess.com](http://worldchess.com/) - Official FIDE broadcasting platform.
 * [chessmatec.com](https://www.chessmatec.com/) - Chess for Kids, an all-in-one chess learning platform for kids (endorsed by the FIDE).
+* [ahamate.app](https://ahamate.app/) - AhaMate, a free one-move chess game for families on one phone: a child learns a fairy-piece secret (Amazon, Cannon, Grasshopper) and builds a trap for a grown-up; no account, no ads.
 * [chesslang](https://chesslang.com/) - A platform for chess academies.
 * [infoszach](https://infoszach.pl/) - Site with news about chess (Polish lang.).
 * [ChessBase](https://en.chessbase.com/) - Reports about chess - tournaments, championships, portraits, interviews, World Championships, product launches and more.


### PR DESCRIPTION
Adding [AhaMate](https://ahamate.app/) next to the other kids/learning entries.

What it is: a free browser game for families — a 5×5 one-move chess board where a child learns a fairy-piece secret (Amazon, Xiangqi Cannon, Grasshopper), builds a trap and hands the phone to a grown-up. Every puzzle is verified by a chess oracle (exactly one winning move). No account, no ads, no trackers; playable in EN/LV/RU.

Disclosure: I'm the maker. Happy to adjust wording or drop it if it doesn't fit the list's scope.